### PR TITLE
have 8 qualities instead of 5

### DIFF
--- a/sctest/contracts/topshot_expanded.cdc
+++ b/sctest/contracts/topshot_expanded.cdc
@@ -288,7 +288,7 @@ pub contract TopShot: NonFungibleToken {
         // returns the ID the new mold
         pub fun castMold(metadata: {String: String}, qualityCounts: {Int: UInt32}): UInt32 {
             pre {
-                qualityCounts.length == 5: "Wrong number of qualities!"
+                qualityCounts.length > 8: "Wrong number of qualities!"
                 metadata.length != 0: "Wrong amount of metadata!"
             }
             var newMold = Mold(id: TopShot.moldID, metadata: metadata, qualityCounts: qualityCounts)


### PR DESCRIPTION
Our current API supports 8 different qualities https://github.com/dapperlabs/nba-api/blob/793664215a7f6aa112da7b17069b03ad8d5fbfea/pkg/grpc/shared/domain/moment.pb.go#L38