### PR TITLE
update play meta data

### DIFF
--- a/contracts/go.mod
+++ b/contracts/go.mod
@@ -3,16 +3,7 @@ module github.com/dapperlabs/nba-smart-contracts/contracts
 go 1.14
 
 require (
-	github.com/ethereum/go-ethereum v1.9.13 // indirect
-	github.com/kevinburke/go-bindata v3.21.0+incompatible // indirect
-	github.com/onflow/cadence v0.4.0 // indirect
 	github.com/onflow/flow-ft/contracts v0.1.2 // indirect
 	github.com/onflow/flow-go-sdk v0.4.0
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79 // indirect
-	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
-	golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 // indirect
-	golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/templates/data/play_metadata.go
+++ b/templates/data/play_metadata.go
@@ -2,42 +2,33 @@ package data
 
 // Cadence requires a mapping of string->string, which can be handled through json tags when marshalling.
 // It also does not allow for null values, so we will be omitting them if empty
+// Reference: https://docs.google.com/spreadsheets/d/1muUZowii0pqoyi6OPK1VPNJi7keSc8_5zI9vu_QvfOY/edit#gid=375111836
 type PlayMetadata struct {
-	// VideoURLs  VideoUrls `sql:"video_urls"`
-	// Images     Images    `sql:"images"`
-
-	// Sport Radar Stats
-	PlayerID                  string `json:",omitempty"`
-	FullName                  string `json:",omitempty"`
-	JerseyNumber              string `json:",omitempty"`
-	TeamAtMoment              string `json:",omitempty"`
-	PrimaryPosition           string `json:",omitempty"`
-	TotalYearsExperience      string `json:",omitempty"`
-	AwayTeamScore             *int32 `json:",omitempty,string"`
-	AwayTeamName              string `json:",omitempty"`
-	HomeTeamName              string `json:",omitempty"`
-	HomeTeamScore             *int32 `json:",omitempty,string"`
-	DateOfMoment              string `json:",omitempty"`
-	TeamAtMomentNBAID         string `json:",omitempty"`
-	CurrentTeam               string `json:",omitempty"`
-	CurrentTeamID             string `json:",omitempty"`
-	Height                    *int32 `json:",omitempty,string"`
-	Weight                    *int32 `json:",omitempty,string"`
-	PlayerGameScores          string `json:",omitempty"`
-	PlayerSeasonAverageScores string `json:",omitempty"`
-	HomeTeamNbaID             string `json:",omitempty"`
-	AwayTeamNbaID             string `json:",omitempty"`
-	NbaSeason                 string `json:",omitempty"`
-	DraftYear                 *int32 `json:",omitempty,string"`
-	DraftSelection            string `json:",omitempty"`
-	DraftRound                string `json:",omitempty"`
-	Birthplace                string `json:",omitempty"`
-	Birthdate                 string `json:",omitempty"`
-	DraftTeam                 string `json:",omitempty"`
-	DraftTeamNbaID            string `json:",omitempty"`
-	PlayType                  string `json:",omitempty"`
-	PlayCategory              string `json:",omitempty"`
-	Quarter                   string `json:",omitempty"`
-	HomeTeamScoresByQuarter   string `json:",omitempty"`
-	AwayTeamScoresByQuarter   string `json:",omitempty"`
+	FullName             string
+	FirstName            string
+	LastName             string
+	Birthdate            string
+	Birthplace           string
+	JerseyNumber         string
+	DraftTeam            string `json:",omitempty"`        // Not all plays have draft information. Can be blank
+	DraftYear            *int32 `json:",omitempty,string"` // Not all plays have draft information. Can be blank
+	DraftSelection       string `json:",omitempty"`        // Not all plays have draft information. Can be blank
+	DraftRound           string `json:",omitempty"`        // Not all plays have draft information. Can be blank
+	TeamAtMomentNBAID    string
+	CurrentTeamID        string
+	TeamAtMoment         string
+	CurrentTeam          string
+	PrimaryPosition      string
+	PlayerPosition       string
+	Height               *int32 `json:",string"`
+	Weight               *int32 `json:",string"`
+	TotalYearsExperience string
+	NbaSeason            string
+	DateOfMoment         string
+	PlayCategory         string
+	PlayType             string
+	HomeTeamName         string
+	AwayTeamName         string
+	HomeTeamScore        *int32 `json:",string"`
+	AwayTeamScore        *int32 `json:",string"`
 }


### PR DESCRIPTION
we added some new metadata to the topshot plays and those aren't sync'd back to this repo yet.
the file was copied over from: https://github.com/dapperlabs/nba-api/blob/master/pkg/flow/topshot/data/play_metadata.go