### PR TITLE
remove CurrentTeam and CurrentTeamID from go templates

### DIFF
--- a/lib/go/templates/data/play_metadata.go
+++ b/lib/go/templates/data/play_metadata.go
@@ -15,9 +15,7 @@ type PlayMetadata struct {
 	DraftSelection       string `json:",omitempty"`        // Not all plays have draft information. Can be blank
 	DraftRound           string `json:",omitempty"`        // Not all plays have draft information. Can be blank
 	TeamAtMomentNBAID    string
-	CurrentTeamID        string
 	TeamAtMoment         string
-	CurrentTeam          string
 	PrimaryPosition      string
 	PlayerPosition       string
 	Height               *int32 `json:",string"`
@@ -44,9 +42,7 @@ func GenerateEmptyPlay(fullName string) PlayMetadata {
 		Birthplace:           "",
 		JerseyNumber:         "",
 		TeamAtMomentNBAID:    "",
-		CurrentTeamID:        "",
 		TeamAtMoment:         "",
-		CurrentTeam:          "",
 		PrimaryPosition:      "",
 		PlayerPosition:       "",
 		Height:               &num,


### PR DESCRIPTION
Deleting fields currentTeam and currentTeamID, they are not supposed to be on chain as they could potentially change

closing: https://app.zenhub.com/workspaces/nba-marketplace-5d9f76cdb6de6d00018d5aa4/issues/dapperlabs/nba/1536

CC: @rrrkren  @joshuahannan 