### PR TITLE
fix typo in args of GenerateBatchTransferMomentScript

### DIFF
--- a/lib/go/templates/topshot_user_templates.go
+++ b/lib/go/templates/topshot_user_templates.go
@@ -85,7 +85,7 @@ func GenerateBatchTransferMomentScript(nftAddr, tokenCodeAddr, recipientAddr flo
 				let receiverRef = recipient.getCapability(/public/MomentCollection).borrow<&{TopShot.MomentCollectionPublic}>()!
 		
 				// deposit the NFT in the receivers collection
-				receiverRef.batchDeposit(token: <-self.transferTokens)
+				receiverRef.batchDeposit(tokens: <-self.transferTokens)
 			}
 		}`
 


### PR DESCRIPTION
seems to be a small typo here, which causes the script to fail with 
```
expected `tokens`, got `token`
``` 
error