### PR TITLE
Fix Damian Lillard typo in `destroy` function's documentation

### DIFF
--- a/contracts/TopShot.cdc
+++ b/contracts/TopShot.cdc
@@ -673,7 +673,7 @@ pub contract TopShot: NonFungibleToken {
 
         // If a transaction destroys the Collection object,
         // All the NFTs contained within are also destroyed!
-        // Much like when Damien Lillard destroys the hopes and
+        // Much like when Damian Lillard destroys the hopes and
         // dreams of the entire city of Houston.
         //
         destroy() {


### PR DESCRIPTION
Referencing the NBA's player page:
https://www.nba.com/player/203081/damian-lillard