### PR TITLE
Add core NFT views placeholder

### DIFF
--- a/contracts/TopShot.cdc
+++ b/contracts/TopShot.cdc
@@ -668,8 +668,8 @@ pub contract TopShot: NonFungibleToken {
                     )
                 case Type<MetadataViews.Editions>():
                     let name = self.getEditionName()
-                    let max = TopShot.getNumMomentsInEdition(setID: self.data.setID, playID: self.data.playID) ?? 0;
-                    let editionInfo = MetadataViews.Edition(name: name, number: UInt64(self.data.serialNumber), max: UInt64(max))
+                    let max = TopShot.getNumMomentsInEdition(setID: self.data.setID, playID: self.data.playID) ?? 0
+                    let editionInfo = MetadataViews.Edition(name: name, number: UInt64(self.data.serialNumber), max: max > 0 ? UInt64(max) : nil)
                     let editionList: [MetadataViews.Edition] = [editionInfo]
                     return MetadataViews.Editions(
                         editionList

--- a/contracts/TopShot.cdc
+++ b/contracts/TopShot.cdc
@@ -692,25 +692,35 @@ pub contract TopShot: NonFungibleToken {
                         providerPath: /private/MomentCollection,
                         publicCollection: Type<&TopShot.Collection{TopShot.MomentCollectionPublic}>(),
                         publicLinkedType: Type<&TopShot.Collection{TopShot.MomentCollectionPublic,NonFungibleToken.Receiver,NonFungibleToken.CollectionPublic,MetadataViews.ResolverCollection}>(),
-                        providerLinkedType: Type<&TopShot.Collection{NonFungibleToken.Provider}>(),
+                        providerLinkedType: Type<&TopShot.Collection{NonFungibleToken.Provider,TopShot.MomentCollectionPublic,NonFungibleToken.Receiver,NonFungibleToken.CollectionPublic,MetadataViews.ResolverCollection}>(),
                         createEmptyCollectionFunction: (fun (): @NonFungibleToken.Collection {
                             return <-TopShot.createEmptyCollection()
                         })
                     )
                 case Type<MetadataViews.NFTCollectionDisplay>():
-                    let media = MetadataViews.Media(
+                    let bannerImage = MetadataViews.Media(
                         file: MetadataViews.HTTPFile(
                             url: "https://nbatopshot.com/static/img/top-shot-logo-horizontal-white.svg"
                         ),
                         mediaType: "image/svg+xml"
                     )
+                    let squareImage = MetadataViews.Media(
+                        file: MetadataViews.HTTPFile(
+                            url: "https://nbatopshot.com/static/img/og/og.png"
+                        ),
+                        mediaType: "image/png"
+                    )
                     return MetadataViews.NFTCollectionDisplay(
-                        name: "NBA TopShot",
+                        name: "NBA-Top-Shot",
                         description: "NBA Top Shot is your chance to own, sell, and trade official digital collectibles of the NBA and WNBA's greatest plays and players",
                         externalURL: MetadataViews.ExternalURL("https://nbatopshot.com"),
-                        squareImage: media,
-                        bannerImage: media,
-                        socials: {}
+                        squareImage: squareImage,
+                        bannerImage: bannerImage,
+                        socials: {
+                            "twitter": MetadataViews.ExternalURL("https://twitter.com/nbatopshot"),
+                            "discord": MetadataViews.ExternalURL("https://discord.com/invite/nbatopshot"),
+                            "instagram": MetadataViews.ExternalURL("https://www.instagram.com/nbatopshot")
+                        }
                     )
                 case Type<MetadataViews.Traits>():
                     let traitDictionary: {String: AnyStruct} = {

--- a/contracts/TopShot.cdc
+++ b/contracts/TopShot.cdc
@@ -617,7 +617,8 @@ pub contract TopShot: NonFungibleToken {
                 Type<MetadataViews.NFTCollectionData>(),
                 Type<MetadataViews.NFTCollectionDisplay>(),
                 Type<MetadataViews.Serial>(),
-                Type<MetadataViews.Traits>()
+                Type<MetadataViews.Traits>(),
+                Type<MetadataViews.Medias>()
             ]
         }
 
@@ -629,7 +630,7 @@ pub contract TopShot: NonFungibleToken {
                     return MetadataViews.Display(
                         name: self.name(),
                         description: self.description(),
-                        thumbnail: MetadataViews.HTTPFile(url: self.imageURL())
+                        thumbnail: MetadataViews.HTTPFile(url: self.thumbnail())
                     )
                 // Custom metadata view unique to TopShot Moments
                 case Type<TopShotMomentMetadataView>():
@@ -680,7 +681,7 @@ pub contract TopShot: NonFungibleToken {
                 case Type<MetadataViews.Royalties>():
                     return MetadataViews.Royalties(
                         royalties: [
-                            // No royalty for Moments yet defined for 3rd party marketplaces
+                            // Reserved for 3rd party marketplace royalty
                         ]
                     )
                 case Type<MetadataViews.ExternalURL>():
@@ -732,6 +733,17 @@ pub contract TopShot: NonFungibleToken {
                         "Serial Number": self.data.serialNumber
                     }
                     return MetadataViews.dictToTraits(dict: traitDictionary, excludedNames: [])
+                case Type<MetadataViews.Medias>():
+                    return MetadataViews.Medias(
+                        items: [
+                            MetadataViews.Media(
+                                file: MetadataViews.HTTPFile(
+                                    url: self.mediumimage()
+                                ),
+                                mediaType: "image/jpeg"
+                            )
+                        ]
+                    )
             }
 
             return nil
@@ -744,7 +756,7 @@ pub contract TopShot: NonFungibleToken {
         pub fun getMomentURL(): String {
             return "https://nbatopshot.com/moment/".concat(self.id.toString())
         }
-        // getEditionName Moment's edition name a combination of the Moment's setName and playID
+        // getEditionName Moment's edition name is a combination of the Moment's setName and playID
         // `setName: #playID`
         pub fun getEditionName() : String {
             let setName: String = TopShot.getSetName(setID: self.data.setID) ?? ""
@@ -752,17 +764,18 @@ pub contract TopShot: NonFungibleToken {
             return editionName
         }
 
-        // imageURL will build the url for the image associated with the moment based on its metadata
-        //
-        // Returns: The computed external url of a medium sized image associated with the moment
-        pub fun imageURL(): String {
-            // The following is an example of what the path should look like:
-            // https://assets.nbatopshot.com/resize/editions/{SETSLUG}/{PLAYID}/play_{PLAYID}_{SETSLUG}_capture_
-            let setSlug = TopShot.getPlayMetaDataByField(playID: self.data.playID, field: "DefaultSetSlug") ?? ""
-            let playGuid = TopShot.getPlayMetaDataByField(playID: self.data.playID, field: "PlayGuid") ?? ""
-            let dynamicPath = setSlug.concat("/").concat(playGuid).concat("/")
-            let imagePrefix = "play_".concat(playGuid).concat("_").concat(setSlug).concat("_capture_")
-            return "https://assets.nbatopshot.com/resize/editions/".concat(dynamicPath).concat(imagePrefix).concat("Hero_2880_2880_Black.jpg")
+        pub fun assetPath(): String {
+            return "https://assets.nbatopshot.com/flow-asset/"
+        }
+
+        // returns a url to display an medium sized image
+        pub fun mediumimage(): String {
+            return self.assetPath().concat(self.data.playID.toString()).concat("_512_512.jpg")
+        }
+
+        // returns a url to display a thumbnail associated with the moment
+        pub fun thumbnail(): String {
+            return self.assetPath().concat(self.data.playID.toString()).concat("_256_256.jpg")
         }
     }
 

--- a/contracts/TopShot.cdc
+++ b/contracts/TopShot.cdc
@@ -748,7 +748,7 @@ pub contract TopShot: NonFungibleToken {
         pub fun imageURL(): String {
             // The following is an example of what the path should look like:
             // https://assets.nbatopshot.com/resize/editions/{SETSLUG}/{PLAYID}/play_{PLAYID}_{SETSLUG}_capture_
-            let setSlug = TopShot.getPlayMetaDataByField(playID: self.data.playID, field: "SetSlug") ?? ""
+            let setSlug = TopShot.getPlayMetaDataByField(playID: self.data.playID, field: "DefaultSetSlug") ?? ""
             let playGuid = TopShot.getPlayMetaDataByField(playID: self.data.playID, field: "PlayGuid") ?? ""
             let dynamicPath = setSlug.concat("/").concat(playGuid).concat("/")
             let imagePrefix = "play_".concat(playGuid).concat("_").concat(setSlug).concat("_capture_")


### PR DESCRIPTION
For discussion, an initial implementation of core NFT views. 
See: https://www.flow-nft-catalog.com/

This should also allow the image url associated with the moment to be resolved on chain.

Notes:
This makes the assumption that the following play metadata will be added (separate PR to the topshot repo forthcoming):
DefaultSetSlug -> The "SetSlug" of the play, currently every play will only have one, but if we end up minting a play into multiple sets we may need to allow per moment overrides for this. 
PlayGuid -> Currently only stored off chain, part of the image URL
Two alternatives to ^ as building image urls on chain dynamically seems out of places.
* Deploy a reverse proxy/gateway/simply another bucket to provide a more ergonomic path for each moment/play (perhaps just requiring the on chain momentId/playId or content hash)
* Store the precomputed full image url (draw back is if the url changes, we'll need to update each play)

Second, there is a metadata view for an external URL for the moment. While we do not currently have a route
for moment by flow id, it seems preferable to add a route for this instead of adding a moment guid on chain for all 50million+ moments. If this External URL is not required, we may also just omit this metadata view if creating a route by flow id will be problematic in the short term.

TODO:
Once we've decided on appropriate patterns for url creation will add unit tests accordingly