### PR TITLE
Remove user moment collection check from destroy moments transaction

### DIFF
--- a/transactions/user/destroy_moments.cdc
+++ b/transactions/user/destroy_moments.cdc
@@ -16,10 +16,8 @@ transaction(momentIDs: [UInt64]) {
         // delist any of the moments that are listed (this delists for both MarketV1 and Marketv3)
         if let topshotSaleV3Collection = acct.borrow<&TopShotMarketV3.SaleCollection>(from: TopShotMarketV3.marketStoragePath) {
             for id in momentIDs {
-                if topshotSaleV3Collection.borrowMoment(id: id) != nil{
-                    // cancel the moment from the sale, thereby de-listing it
-                    topshotSaleV3Collection.cancelSale(tokenID: id)
-                }
+                // cancel the moment from the sale, thereby de-listing it
+                topshotSaleV3Collection.cancelSale(tokenID: id)
             }
         }
 


### PR DESCRIPTION
We had around 50 cases where the moments weren't delisted on NBA bc the `cancelSale` wasn't called, and we are not sure what caused this problem.

We do have cases known as ghost listings, where listings are still active on the user's marketplace while they don't own the moments anymore

`cancelSale`: https://github.com/dapperlabs/nba-smart-contracts/blob/master/contracts/TopShotMarketV3.cdc#L157

Example:
https://flowscan.org/transaction/9e80e9914a3224c687e680fba7dbbc8da67ae60750ed96083ba2d3e157a510f1/script

Other cases:
```
52f7748d66bcfec53bacd96ccdf3d6f172289627e9c8b7cea0afd2b5fe866c84
eb0e026282dd11b9d64fb7809266ae14ed01100f587b42c76b7dbfbf337c3116
67415832e21a7bdd3eb3ae045f20b5e2ab3530d5be19dc7945dc30ae752ee0f5
67415832e21a7bdd3eb3ae045f20b5e2ab3530d5be19dc7945dc30ae752ee0f5
08083cd219b24fcafc6faf8904fcf09c1716617e5f30c40a3a7a90173d501848
3e48121a2a3b20a7056298b6141d09da4336f5ca8455471028a3bffe32ce0bb1
39b5b69a43f174fa8e88c969c0face3403a4fbfdb259db9df5659722a3ea070e
39b5b69a43f174fa8e88c969c0face3403a4fbfdb259db9df5659722a3ea070e
eb0e026282dd11b9d64fb7809266ae14ed01100f587b42c76b7dbfbf337c3116
5ba03f3656002528a5a2be46df8c5b08fe6784850cd85e41e2405be7f207f3a6
a803623712cdd4657ef52fcd941ec77a32046679eb13ce7877ac2fc34bc37cdd
c07d75a7306658aaf8c83d0ae21b02d5f6e1bab7f0431882615c605579fe1679
1c24d7e50e61f963523fe8f746a0cffee00094b4fbc4d7ce089f9e1badeda23b
c07d75a7306658aaf8c83d0ae21b02d5f6e1bab7f0431882615c605579fe1679
a5a87a54c413e6ce68d4d261d71d656dba9b9990c23d694472eb5b27e21da2b7
8d97fc764aa60937955778547fb2290a7f5d8a6c8417e2707bce4fdcb3b379f1
70d958c40cf98d8697ad1209ef14e28a9e2ce522fb330ec560bcc812aa013b5f
70d958c40cf98d8697ad1209ef14e28a9e2ce522fb330ec560bcc812aa013b5f
7bafc9178fcd7e0e229f2fe698800b8fb22ab155c1945fe0fedb4f37b1bbac66
5c6ee81d91c1c1501c96868179858fb8c44d39d05b8ad4943a4d5af77b4c21c7
aa3f975dd11cc745b2df8312e9cdf525508cd777afe7ec71daed9906df8ad517
dce2cd57640471cc015e5b15c89f55c4597bbb825b1a2c8bb59675ae187038f3
7adccd5fc9d2eccb689444727250ae8bcfbd4297dd2ea981cf2911c9bdca9b31
aa3f975dd11cc745b2df8312e9cdf525508cd777afe7ec71daed9906df8ad517
f54fb8ad0ce8539ee3e3e2b641a068d51088530c13c3c43e4c10e022cb25db5b
70c2bb24b26a29e846733d9c5f10186e2f623ed76ccf4fe16b3e76b2d713800e
541bb548a5d1c79a8bc90ac7c4923142cf4dce52b796b87d6866411aad28e2a3
70c2bb24b26a29e846733d9c5f10186e2f623ed76ccf4fe16b3e76b2d713800e
541bb548a5d1c79a8bc90ac7c4923142cf4dce52b796b87d6866411aad28e2a3
666b3f44247bda0a2bf6142880d5b0eef39f96fe0e2e8cf395499adcabc3eda1
fbe964e1a0ca940d543714ec00f11c7f575d6ff784aef95a792f162be85ec1e8
5c5b2e0811d441a5a7b2f4576122a580e9efb5b25c7ef77cbfd8ea78573a4c54
cc09d6080ac48641a2b1d555dc405db8452c12dbef308cd14faac631d14dd2c8
cc09d6080ac48641a2b1d555dc405db8452c12dbef308cd14faac631d14dd2c8
1ec985a2b525299bbf335fbbd678b66a7cda16d1c4e9b2aa042cbe10ab19fefd
9e80e9914a3224c687e680fba7dbbc8da67ae60750ed96083ba2d3e157a510f1
6a60345ebebc45eaa192bd51f48ee62efa2a5051aa98341e9929cb415744b96d
24d669b522559a0f4f5141972d08a943da0a2d01dfb2421fa401e08cbaac9895
69a36ffa39cf76898b64a79d0e3c869dc7dc7ac6299c42154369a00c56dbe9b8
b3dc1d8073fc38f8d6833af07f65d23dc21ae58e06ca73c35444c957d960bed6
b45bfde52e3b5fbe347f1233ebbf09280a3c46adc8dd18e64ac5af7f39634b34
b45bfde52e3b5fbe347f1233ebbf09280a3c46adc8dd18e64ac5af7f39634b34
698f2a01eaaaacbe45dbe19387b751da4faedd116e433c0cf4a1d05a6f39cb51
911cabc90ff0e8f629ffe5020778df0b2b14b96e6c80d01fe65a14ab78d498cd
951540e388f65fc404f92ee885f13941cc9b3d29357529e32ff6cbba4ee2e6fa
951540e388f65fc404f92ee885f13941cc9b3d29357529e32ff6cbba4ee2e6fa
f8813088e743b53794530c59933a8c6daa8ce4b5656c13616f00c6b4b1a9446a
1623b776472d4e7c90c71fd711f7a888e1df3fa85917d93b552710baad3cb353
d14a81b8573e151da42f394c6560bfcd6874deb7bef5ec8867dc6223a6b1e8bb
7bc255606358f848dd3f5037d0c30bb7484c2b3ae33bffe6ebed165de0375126
1623b776472d4e7c90c71fd711f7a888e1df3fa85917d93b552710baad3cb353
7bc255606358f848dd3f5037d0c30bb7484c2b3ae33bffe6ebed165de0375126
```