### PR TITLE
Try to refill custodial accounts

### DIFF
--- a/contracts/TopShot.cdc
+++ b/contracts/TopShot.cdc
@@ -47,6 +47,7 @@ import FungibleToken from 0xFUNGIBLETOKENADDRESS
 import NonFungibleToken from 0xNFTADDRESS
 import MetadataViews from 0xMETADATAVIEWSADDRESS
 import TopShotLocking from 0xTOPSHOTLOCKINGADDRESS
+import DapperStorageRent from 0xDAPPERSTORAGERENTADDRESS
 
 pub contract TopShot: NonFungibleToken {
     // -----------------------------------------------------------------------
@@ -1158,6 +1159,12 @@ pub contract TopShot: NonFungibleToken {
 
             // Get the token's ID
             let id = token.id
+
+            // For custodial accounts, ensure there is sufficient 
+            // storage capacity to store the token
+            if self.owner?.address != nil {
+                DapperStorageRent.tryRefill(self.owner?.address)
+            }
 
             // Add the new token to the dictionary
             let oldToken <- self.ownedNFTs[id] <- token


### PR DESCRIPTION
One way to approach issue:
https://github.com/dapperlabs/nba-smart-contracts/issues/183

We will check the storage before depositing, this check should fail silently for non dapper accounts, and have the benefit of allowing third parties depositing moments into a custodial account to not need to modify their tx.

See:
https://github.com/dapperlabs/dapper-flow-contracts/tree/c6496eeb26022b8ada7666e79f98d1fce5d9b158/dapper-storage-rent
for impl of storage check