### PR TITLE
chore: add event models for moment locking

### DIFF
--- a/lib/go/events/moment_locked.go
+++ b/lib/go/events/moment_locked.go
@@ -1,0 +1,55 @@
+package events
+
+import (
+	"fmt"
+	"github.com/onflow/cadence"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+)
+
+var (
+	MomentLocked = "TopShotLocking.MomentLocked"
+)
+
+type MomentLockedEvent interface {
+	FlowID() uint64
+	Duration() uint64
+	ExpiryTimestamp() uint64
+}
+
+type momentLockedEvent cadence.Event
+
+func (evt momentLockedEvent) FlowID() uint64 {
+	return uint64(evt.Fields[0].(cadence.UInt64))
+}
+
+func (evt momentLockedEvent) Duration() uint64 {
+	return uint64(evt.Fields[1].(cadence.UInt64))
+}
+
+func (evt momentLockedEvent) ExpiryTimestamp() uint64 {
+	return uint64(evt.Fields[2].(cadence.UInt64))
+}
+
+func (evt momentLockedEvent) validate() error {
+	if evt.EventType.QualifiedIdentifier != MomentLocked {
+		return fmt.Errorf("error validating event: event is not a valid moment locked event, expected type %s, got %s",
+			MomentLocked, evt.EventType.QualifiedIdentifier)
+	}
+	return nil
+}
+
+var _ MomentLockedEvent = (*momentLockedEvent)(nil)
+
+func DecodeMomentLockedEvent(b []byte) (MomentLockedEvent, error) {
+	value, err := jsoncdc.Decode(nil, b)
+	if err != nil {
+		return nil, err
+	}
+
+	event := momentLockedEvent(value.(cadence.Event))
+	if err := event.validate(); err != nil {
+		return nil, fmt.Errorf("error decoding event: %w", err)
+	}
+
+	return event, nil
+}

--- a/lib/go/events/moment_unlocked.go
+++ b/lib/go/events/moment_unlocked.go
@@ -1,0 +1,45 @@
+package events
+
+import (
+	"fmt"
+	"github.com/onflow/cadence"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+)
+
+var (
+	MomentUnlocked = "TopShotLocking.MomentUnlocked"
+)
+
+type MomentUnlockedEvent interface {
+	FlowID() uint64
+}
+
+type momentUnlockedEvent cadence.Event
+
+func (evt momentUnlockedEvent) FlowID() uint64 {
+	return uint64(evt.Fields[0].(cadence.UInt64))
+}
+
+func (evt momentUnlockedEvent) validate() error {
+	if evt.EventType.QualifiedIdentifier != MomentUnlocked {
+		return fmt.Errorf("error validating event: event is not a valid moment unlocked event, expected type %s, got %s",
+			MomentUnlocked, evt.EventType.QualifiedIdentifier)
+	}
+	return nil
+}
+
+var _ MomentUnlockedEvent = (*momentUnlockedEvent)(nil)
+
+func DecodeMomentUnlockedEvent(b []byte) (MomentUnlockedEvent, error) {
+	value, err := jsoncdc.Decode(nil, b)
+	if err != nil {
+		return nil, err
+	}
+
+	event := momentUnlockedEvent(value.(cadence.Event))
+	if err := event.validate(); err != nil {
+		return nil, fmt.Errorf("error decoding event: %w", err)
+	}
+
+	return event, nil
+}


### PR DESCRIPTION
These were originally put in nba-api internal but they make more sense living alongside the contracts like the other events
https://github.com/dapperlabs/nba-api/blob/master/internal/momentlocking/events/moment_locked.go