### PR TITLE
allow moment id casting to be either uint32 or uint64

### DIFF
--- a/lib/go/events/moment.go
+++ b/lib/go/events/moment.go
@@ -23,7 +23,12 @@ type MomentMintedEvent interface {
 type momentMintedEvent cadence.Event
 
 func (evt momentMintedEvent) MomentId() uint64 {
-	return uint64(evt.Fields[0].(cadence.UInt64))
+	id64, ok := evt.Fields[0].(cadence.UInt64)
+	if ok {
+		return uint64(id64)
+	} else {
+		return uint64(evt.Fields[0].(cadence.UInt32))
+	}
 }
 
 func (evt momentMintedEvent) PlayId() uint32 {


### PR DESCRIPTION
 I observed the following casting error when processing MomentMinted events
```panic: interface conversion: cadence.Value is cadence.UInt32, not cadence.UInt64```