### PR TITLE
test: fix tests to use new MetadataViews imports

### DIFF
--- a/lib/go/test/topshot_test.go
+++ b/lib/go/test/topshot_test.go
@@ -30,8 +30,8 @@ const (
 
 	emulatorFTAddress         = "ee82856bf20e2aa6"
 	emulatorFlowTokenAddress  = "0ae53cb6e3f42a79"
-	MetadataFTReplaceAddress  = `"./utility/FungibleToken.cdc"`
-	MetadataNFTReplaceAddress = `"./NonFungibleToken.cdc"`
+	MetadataFTReplaceAddress  = `"FungibleToken"`
+	MetadataNFTReplaceAddress = `"NonFungibleToken"`
 	Network                   = `"mainnet"`
 )
 


### PR DESCRIPTION
Onflow updated their metadataviews contract, our tests download from github and use the contract.

This PR contains the new import format:
https://github.com/onflow/flow-nft/commit/78011943223190245ef818b1d1f2e8d67126d6c4#diff-a7af41cf43e29d0e6028827c3d5f305326677661bf65d79539d59ed1056c0a84R1
