### PR TITLE
emit withdraw event when burning

### DIFF
--- a/contracts/TopShot.cdc
+++ b/contracts/TopShot.cdc
@@ -1249,6 +1249,10 @@ pub contract TopShot: NonFungibleToken {
                 let token <- self.ownedNFTs.remove(key: id)
                     ?? panic("Cannot destroy: Moment does not exist in collection: ".concat(id.toString()))
 
+                // Emit a withdraw event here so that platforms do not have to understand TopShot-specific events to see ownership change
+                // A withdraw without a corresponding deposit means the NFT in question has no owner address
+                emit Withdraw(id: id, from: self.owner?.address)
+
                 // does nothing if the moment is not locked
                 topShotLockingAdmin.unlockByID(id: id)
 


### PR DESCRIPTION
There is no standard destruction event that all NFT Collections follow. Because of that, indexers that pull in all NFT events on flow can miss destruction events if there is no corresponding withdraw to go along with it.

This change will emit a withdraw event to signal to indexers that ownership of an item has changed along with it being burned. This will ensure that indexers at least see that ownership is empty at the end of a transaction without needing to know that anything about TopShot itself