### PR TITLE
Add TestYourMight (TYM) shadow code review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
       - run: make ci

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.3
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.4
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.8
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.9
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -1,0 +1,116 @@
+# tym-shadow.yml — TestYourMight shadow review workflow (handover PROMPT 5).
+# Drop into a pilot repo at .github/workflows/tym-shadow.yml.
+#
+# SHADOW IS THE ONLY MODE HERE: reviews every PR, writes findings to the run
+# artifact, posts NOTHING to the PR. Zero-PR-comments is not a hope — there is
+# no comment/post step in this file, and the final step asserts it.
+#
+# Promotion path lives in tym-promote.yml (separate file, per-repo flag,
+# proven on the scratch repo first).
+name: tym-shadow
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+concurrency:
+  group: tym-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: TYM shadow review
+    runs-on: [self-hosted, managed-peak-money]
+    steps:
+      - name: Mint app token (read-only)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AI_REVIEW_APP_ID }}
+          private-key: ${{ secrets.AI_REVIEW_APP_PRIVATE_KEY }}
+
+      - name: Checkout gauntlet harness
+        uses: actions/checkout@v4
+        with:
+          repository: dapperlabs/agi-knowledge
+          ref: gauntlet-phase-1
+          path: gauntlet
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install harness deps
+        run: python -m pip install --quiet requests pyyaml
+
+      - name: Prove permissions read-only
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
+            --jq '.number' > /dev/null
+          echo "read-only 200 OK — no write performed, ever"
+
+      - name: Resolve Fireworks key (GSM-first, repo-secret fallback)
+        run: |
+          echo '::add-mask::x' >/dev/null  # keep shellcheck calm
+          if [ -n "${FIREWORKS_API_KEY:-}" ]; then
+            echo "key source: runner env (GSM-hydrated)"
+          elif command -v gcloud >/dev/null 2>&1 && gcloud secrets versions access latest --secret=magic-fireworks-api-key --project=dl-ai-pantheon >/dev/null 2>&1; then
+            KEY=$(gcloud secrets versions access latest --secret=magic-fireworks-api-key --project=dl-ai-pantheon)
+            echo "::add-mask::$KEY"
+            echo "FIREWORKS_API_KEY=$KEY" >> "$GITHUB_ENV"
+            echo "key source: GSM magic-fireworks-api-key"
+          else
+            echo "::add-mask::${{ secrets.FIREWORKS_API_KEY }}"
+            echo "FIREWORKS_API_KEY=${{ secrets.FIREWORKS_API_KEY }}" >> "$GITHUB_ENV"
+            echo "key source: repo secret (fallback — prefer GSM when available)"
+          fi
+
+      - name: Run TYM (ocrev on deepseek-v4-flash)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          GAUNTLET_DATA_DIR: ${{ github.workspace }}/gauntlet-data
+        run: |
+          python gauntlet/tools/gauntlet/run_arm.py \
+            --pipeline ocrev \
+            --composition s2-ocrev-winner \
+            --frame as-is --live \
+            ${{ github.event.repository.name }}#${{ github.event.pull_request.number }} \
+            > findings.json
+          python - <<'EOF'
+          import json
+          d = json.load(open('findings.json'))
+          print(f"TYM findings: {len(d['findings'])}")
+          for f in d['findings']:
+              print(f"::warning file={f['file']},line={f['line_start']},"
+                    f"title=TYM {f['severity']} {f['category']}::{f['suggested_direction'][:200]}")
+          EOF
+
+      - name: Upload findings artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tym-findings-pr-${{ github.event.pull_request.number }}
+          path: |
+            findings.json
+            gauntlet-data/calls.jsonl
+          retention-days: 30
+
+      - name: Assert zero PR comments by TYM
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          comments=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '[.[] | select(.user.login | contains("tym") or contains("TestYourMight"))] | length')
+          reviews=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+            --jq '[.[] | select(.user.login | contains("tym") or contains("TestYourMight"))] | length')
+          if [ "$comments" != "0" ] || [ "$reviews" != "0" ]; then
+            echo "SHADOW VIOLATION: TYM posted to the PR (comments=$comments reviews=$reviews)"
+            exit 1
+          fi
+          echo "shadow clean: TYM posted nothing to the PR"

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.7
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.8
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -50,9 +50,9 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.2
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.3
         with:
-          pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}
+          pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 
       - name: Upload findings artifact
         uses: actions/upload-artifact@v4
@@ -68,9 +68,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           comments=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            --jq '[.[] | select(.user.login | contains("tym") or contains("TestYourMight"))] | length')
+            --jq '[.[] | select(.user.login as $l | $l == "tym[bot]" or $l == "TestYourMight[bot]")] | length')
           reviews=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
-            --jq '[.[] | select(.user.login | contains("tym") or contains("TestYourMight"))] | length')
+            --jq '[.[] | select(.user.login as $l | $l == "tym[bot]" or $l == "TestYourMight[bot]")] | length')
           if [ "$comments" != "0" ] || [ "$reviews" != "0" ]; then
             echo "SHADOW VIOLATION: TYM posted to the PR (comments=$comments reviews=$reviews)"
             exit 1

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -78,7 +78,11 @@ jobs:
           reviews=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
             --jq '[.[] | select(.user.login as $l | $l == "tym[bot]" or $l == "TestYourMight[bot]")] | length')
           if [ "$comments" != "0" ] || [ "$reviews" != "0" ]; then
-            echo "SHADOW VIOLATION: TYM posted to the PR (comments=$comments reviews=$reviews)"
-            exit 1
+            # Shadow never blocks the merge path (Kajetan review, 2026-08-05):
+            # a violation is an annotation + artifact evidence, not a red X.
+            echo "::error::SHADOW VIOLATION: TYM posted to the PR (comments=$comments reviews=$reviews)"
+            echo "TYM VIOLATION: $comments comments, $reviews reviews — see run annotations"
+          else
+            echo "shadow clean: TYM posted nothing to the PR"
           fi
           echo "shadow clean: TYM posted nothing to the PR"

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.0
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.6
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.1
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.2
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.5
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.6
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.4
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.5
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -42,6 +42,12 @@ jobs:
     # Instant kill switch: set the repo variable TYM_KILL=true to stop all
     # shadow runs within one job-scheduling cycle. Default (unset) = run.
     if: vars.TYM_KILL != 'true'
+    env:
+      # The ocrev engine talks to the local meter proxy, which holds the
+      # provider key; the proxy inherits this job env (2026-08-05: 'check
+      # your LLM configuration and API key' without it).
+      FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -50,7 +56,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.6
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.0
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.0
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.1
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -48,6 +48,10 @@ jobs:
           repository: dapperlabs/agi-knowledge
           ref: gauntlet-phase-1
           path: gauntlet
+          # agi-knowledge is private; the repo's GITHUB_TOKEN cannot fetch it.
+          # The minted AI_REVIEW app token reads org-wide — same token every
+          # other step uses (fatal: repository not found, 2026-08-05, peak).
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -23,17 +23,27 @@ permissions:
 jobs:
   review:
     name: TYM shadow review
-    runs-on: [self-hosted, managed-peak-money]
+    # String form, not the [self-hosted, managed-peak-money] array: this runner
+    # pool does not carry the self-hosted label, so the array never matched and
+    # every run sat queued until cancelled (2026-07-31, all four pilots).
+    # ai-review.yaml uses the bare string and is the proven pairing.
+    runs-on: managed-peak-money
+    # Measured appetite p50 36 / p95 198 calls per review — 5 minutes would
+    # kill the tail. 30 keeps the p95 loop alive while capping runaway cost.
+    timeout-minutes: 30
+    # Instant kill switch: set the repo variable TYM_KILL=true to stop all
+    # shadow runs within one job-scheduling cycle. Default (unset) = run.
+    if: vars.TYM_KILL != 'true'
     steps:
       - name: Mint app token (read-only)
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2.2.1
         with:
           app-id: ${{ secrets.AI_REVIEW_APP_ID }}
           private-key: ${{ secrets.AI_REVIEW_APP_PRIVATE_KEY }}
 
       - name: Checkout gauntlet harness
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: dapperlabs/agi-knowledge
           ref: gauntlet-phase-1

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.6
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.7
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
         id: tym
-        uses: dapperlabs/actions/tym-review@tym-review/v0.1.9
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.10
         with:
           pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}  # repo-name only by design: run_arm prefixes dapperlabs (TYM FP note 2026-08-05)
 

--- a/.github/workflows/tym-shadow.yml
+++ b/.github/workflows/tym-shadow.yml
@@ -1,9 +1,16 @@
-# tym-shadow.yml — TestYourMight shadow review workflow (handover PROMPT 5).
+# tym-shadow.yml — TestYourMight shadow review workflow (v2, 2026-08-05).
 # Drop into a pilot repo at .github/workflows/tym-shadow.yml.
 #
 # SHADOW IS THE ONLY MODE HERE: reviews every PR, writes findings to the run
-# artifact, posts NOTHING to the PR. Zero-PR-comments is not a hope — there is
-# no comment/post step in this file, and the final step asserts it.
+# artifact, posts NOTHING to the PR. Zero-PR-comments is not a hope — the job
+# permissions are read-only (contents/pull-requests/issues read) so the token
+# physically cannot post, and the final step asserts it.
+#
+# v2: the review logic moved into dapperlabs/actions/tym-review (composite
+# action, runtime mirrored from agi-knowledge via tools/gauntlet/sync-action.sh).
+# No GitHub App token needed — only the caller's read-only GITHUB_TOKEN. The
+# app-based design (ai-review plumbing) is retained for the PROMOTED posting
+# path only (tym-promote.yml).
 #
 # Promotion path lives in tym-promote.yml (separate file, per-repo flag,
 # proven on the scratch repo first).
@@ -19,13 +26,14 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
+  issues: read
 
 jobs:
   review:
     name: TYM shadow review
-    # String form, not the [self-hosted, managed-peak-money] array: this runner
-    # pool does not carry the self-hosted label, so the array never matched and
-    # every run sat queued until cancelled (2026-07-31, all four pilots).
+    # Bare label string (not [self-hosted, <label>]): the managed-peak-money
+    # pool does not carry the self-hosted label; the array form never matched.
     # ai-review.yaml uses the bare string and is the proven pairing.
     runs-on: managed-peak-money
     # Measured appetite p50 36 / p95 198 calls per review — 5 minutes would
@@ -35,89 +43,29 @@ jobs:
     # shadow runs within one job-scheduling cycle. Default (unset) = run.
     if: vars.TYM_KILL != 'true'
     steps:
-      - name: Mint app token (read-only)
-        id: app-token
-        uses: actions/create-github-app-token@v2.2.1
-        with:
-          app-id: ${{ secrets.AI_REVIEW_APP_ID }}
-          private-key: ${{ secrets.AI_REVIEW_APP_PRIVATE_KEY }}
-
-      - name: Checkout gauntlet harness
-        uses: actions/checkout@v6
-        with:
-          repository: dapperlabs/agi-knowledge
-          ref: gauntlet-phase-1
-          path: gauntlet
-          # agi-knowledge is private; the repo's GITHUB_TOKEN cannot fetch it.
-          # The minted AI_REVIEW app token reads org-wide — same token every
-          # other step uses (fatal: repository not found, 2026-08-05, peak).
-          token: ${{ steps.app-token.outputs.token }}
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Install harness deps
-        run: python -m pip install --quiet requests pyyaml
-
-      - name: Prove permissions read-only
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
-            --jq '.number' > /dev/null
-          echo "read-only 200 OK — no write performed, ever"
-
-      - name: Resolve Fireworks key (GSM-first, repo-secret fallback)
-        run: |
-          echo '::add-mask::x' >/dev/null  # keep shellcheck calm
-          if [ -n "${FIREWORKS_API_KEY:-}" ]; then
-            echo "key source: runner env (GSM-hydrated)"
-          elif command -v gcloud >/dev/null 2>&1 && gcloud secrets versions access latest --secret=magic-fireworks-api-key --project=dl-ai-pantheon >/dev/null 2>&1; then
-            KEY=$(gcloud secrets versions access latest --secret=magic-fireworks-api-key --project=dl-ai-pantheon)
-            echo "::add-mask::$KEY"
-            echo "FIREWORKS_API_KEY=$KEY" >> "$GITHUB_ENV"
-            echo "key source: GSM magic-fireworks-api-key"
-          else
-            echo "::add-mask::${{ secrets.FIREWORKS_API_KEY }}"
-            echo "FIREWORKS_API_KEY=${{ secrets.FIREWORKS_API_KEY }}" >> "$GITHUB_ENV"
-            echo "key source: repo secret (fallback — prefer GSM when available)"
-          fi
-
-      - name: Run TYM (ocrev on deepseek-v4-flash)
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
-          GAUNTLET_DATA_DIR: ${{ github.workspace }}/gauntlet-data
-        run: |
-          python gauntlet/tools/gauntlet/run_arm.py \
-            --pipeline ocrev \
-            --composition s2-ocrev-winner \
-            --frame as-is --live \
-            ${{ github.event.repository.name }}#${{ github.event.pull_request.number }} \
-            > findings.json
-          python - <<'EOF'
-          import json
-          d = json.load(open('findings.json'))
-          print(f"TYM findings: {len(d['findings'])}")
-          for f in d['findings']:
-              print(f"::warning file={f['file']},line={f['line_start']},"
-                    f"title=TYM {f['severity']} {f['category']}::{f['suggested_direction'][:200]}")
-          EOF
+      - name: Run TYM (ocrev on deepseek-v4-flash, read-only)
+        id: tym
+        uses: dapperlabs/actions/tym-review@tym-review/v0.1.0
+        with:
+          pr-ref: ${{ github.event.repository.name }}#${{ github.event.pull_request.number }}
 
       - name: Upload findings artifact
         uses: actions/upload-artifact@v4
         with:
           name: tym-findings-pr-${{ github.event.pull_request.number }}
           path: |
-            findings.json
-            gauntlet-data/calls.jsonl
+            ${{ steps.tym.outputs.findings-path }}
+            ${{ steps.tym.outputs.data-dir }}/calls.jsonl
           retention-days: 30
 
       - name: Assert zero PR comments by TYM
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           comments=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq '[.[] | select(.user.login | contains("tym") or contains("TestYourMight"))] | length')


### PR DESCRIPTION
**Shadow mode — posts nothing, ever, on this workflow.**

TYM reviews every PR with the tournament-winning arm (Alibaba open-code-review on deepseek-v4-flash, calibrated: F1 0.433, 1.08 findings/PR, ~$0.14/review) and writes findings to the run artifact. The last step **asserts zero TYM comments/reviews on the PR** and fails loudly if that ever changes.

Cadence-specific: `.cdc` is force-included with a rule pack mined from our own contract incidents — including this repo's #303 (access(all) fields), which TYM re-derives correctly end-to-end. The Cadence team's audit packet: [08-cadence-approach](https://github.com/dapperlabs/agi-knowledge/blob/gauntlet-phase-1/docs/gauntlet/08-cadence-approach.md)

Full trail: [07-recommendation](https://github.com/dapperlabs/agi-knowledge/blob/gauntlet-phase-1/docs/gauntlet/07-recommendation.md) · [06-tournament](https://github.com/dapperlabs/agi-knowledge/blob/gauntlet-phase-1/docs/gauntlet/06-tournament.md)