### PR TITLE
Complete Go transaction surface, correct market contract status, bridge hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ the core functionality of the NFT.
 
 > **Note**: Bridged Top Shot Moments are available on Flow EVM. See the [EVM Bridging README](evm-bridging/README.md) for contract addresses and details.
 
-`MarketTopShot.cdc`: This is the top shot marketplace contract that allows users
-to buy and sell their NFTs.
+`TopShotMarketV3.cdc`: This is the operative Top Shot marketplace contract (V3; the
+original `Market.cdc` is legacy — see "Different Versions of the Market Contract" below)
+that allows users to buy and sell their NFTs.
 
 | Network | Contract Address     |
 |---------|----------------------|
@@ -70,6 +71,10 @@ please familiarize yourself with the Flow NFT standard before starting and make 
 in your project in order to be interoperable with other tokens and contracts that implement the standard.
 
 ### Top Shot Marketplace contract
+
+This section describes the original `Market.cdc` (V1). The operative contract
+is `TopShotMarketV3.cdc` (V3), which implements the capability-based best
+practice described below.
 
 The top shot marketplace contract was designed in the very early days of Cadence, and therefore
 uses some language features that are NOT RECOMMENDED to use by newer projects.
@@ -398,26 +403,30 @@ and if they sent the correct amount, they get the Moment back.
 
 ### Different Versions of the Market Contract
 
-There are two versions of the Top Shot Market Contract.
-`TopShotMarket.cdc` is the original version of the contract that was used
+There are three versions of the Top Shot Market Contract.
+`Market.cdc` is the original version of the contract that was used
 for the first set of sales in the p2p marketplace, but we made improvements
 to it which are now in `TopShotMarketV3.cdc`.
 
-There is also a V2 version that was deployed to mainnet, but will never be used.
+There is also a V2 version (`TopShotMarketV2.cdc`) that was deployed to
+mainnet but is unused — it must never be consumed.
 
-Both versions define a `SaleCollection` resource that users store in their account.
-The resource manages the logic of the sale like listings, de-listing, prices, and 
-purchases. The first version actually stores the moments that are for sale, but 
+Both the original and V3 define a `SaleCollection` resource that users store in their account.
+The resource manages the logic of the sale like listings, de-listing, prices, and
+purchases. The first version actually stores the moments that are for sale, but
 we realized that this causes issues if other contracts need to access a user's
 main collection to see what they own. We created the second version to simply
-store a capability to the owner's moment collection so that the moments 
+store a capability to the owner's moment collection so that the moments
 that are for sale do not need to be removed from the main collection to be
 put up for sale. In this version, when a moment is purchased, the sale collection
-uses the capability to withdraw the moment from the main collection and 
+uses the capability to withdraw the moment from the main collection and
 returns it to the buyer.
 
-The new version of the market contract is currently NOT DEPLOYED to mainnet,
-but it will be deployed and utilized in the near future.
+**`TopShotMarketV3.cdc` is the operative market contract.** It is deployed
+on Mainnet (`0xc1e4f4f4c4257510`) and Testnet (`0x547f177b243b4d80`) — see
+the address table above. V3 holds a capability to the seller's Moment
+collection (no custody), and it falls back to the original sale surface for
+legacy V1 listings.
 
 ## TopShot contract improvement
 Some improvements were made to the Topshot contract to reflect some cadence best practices and fix a bug.

--- a/embed.go
+++ b/embed.go
@@ -86,6 +86,9 @@ var (
 	//go:embed transactions/admin/unlock_all_moments.cdc
 	AdminUnlockAllMoments []byte
 
+	//go:embed transactions/admin/set_ipfs_cids.cdc
+	AdminSetIpfsCids []byte
+
 	// marketV3
 	//go:embed transactions/marketV3/purchase_both_markets.cdc
 	Marketv3PurchaseBothMarkets []byte
@@ -304,6 +307,9 @@ var (
 
 	//go:embed transactions/fastbreak/oracle/create_run.cdc
 	FastbreakOracleCreateRun []byte
+
+	//go:embed transactions/fastbreak/oracle/update_submission_deadline.cdc
+	FastbreakOracleUpdateSubmissionDeadline []byte
 
 	// fastbreak/scripts
 	//go:embed transactions/fastbreak/scripts/get_fast_break_stats.cdc

--- a/evm-bridging/script/InitialTestingDeploy.s.sol
+++ b/evm-bridging/script/InitialTestingDeploy.s.sol
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
+// ⚠️ TEST-ONLY — DO NOT USE FOR ANY REAL DEPLOYMENT.
+// This script hardcodes placeholder values: underlying=0x12345,
+// vmBridge=0x67890, a cryptokitties token URI, and dummy Cadence identifiers.
+// Any production deployment must supply the real underlying contract address,
+// the real VM bridge address, and correct metadata. Reviewed 2026-09-08.
+
 import {Script} from "forge-std/Script.sol";
 import "forge-std/console.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/src/Upgrades.sol";

--- a/evm-bridging/src/BridgedTopShotMoments.sol
+++ b/evm-bridging/src/BridgedTopShotMoments.sol
@@ -165,7 +165,7 @@ contract BridgedTopShotMoments is
             || interfaceId == type(IERC721Enumerable).interfaceId || interfaceId == type(ERC721BurnableUpgradeable).interfaceId
             || interfaceId == type(OwnableUpgradeable).interfaceId || interfaceId == type(ICrossVM).interfaceId
             || interfaceId == type(ICreatorToken).interfaceId || interfaceId == type(ILegacyCreatorToken).interfaceId
-            || interfaceId == type(IERC2981).interfaceId || super.supportsInterface(interfaceId);
+            || interfaceId == type(IERC2981).interfaceId || interfaceId == type(IERC4906).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function _setSymbol(string memory newSymbol) internal {

--- a/evm-bridging/src/test-contracts/TestNFTContract.sol
+++ b/evm-bridging/src/test-contracts/TestNFTContract.sol
@@ -165,7 +165,7 @@ contract TestNFTContract is
             || interfaceId == type(IERC721Enumerable).interfaceId || interfaceId == type(ERC721BurnableUpgradeable).interfaceId
             || interfaceId == type(OwnableUpgradeable).interfaceId || interfaceId == type(ICrossVM).interfaceId
             || interfaceId == type(ICreatorToken).interfaceId || interfaceId == type(ILegacyCreatorToken).interfaceId
-            || interfaceId == type(IERC2981).interfaceId || super.supportsInterface(interfaceId);
+            || interfaceId == type(IERC2981).interfaceId || interfaceId == type(IERC4906).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function _setSymbol(string memory newSymbol) internal {

--- a/lib/go/templates/fastbreak_oracle_templates.go
+++ b/lib/go/templates/fastbreak_oracle_templates.go
@@ -10,6 +10,7 @@ const (
 	addStatToFastBreakGameFilename   = "fastbreak/oracle/add_stat_to_game.cdc"
 	updateFastBreakGameFilename      = "fastbreak/oracle/update_fast_break_game.cdc"
 	scoreFastBreakSubmissionFilename = "fastbreak/oracle/score_fast_break_submission.cdc"
+	updateSubmissionDeadlineFilename = "fastbreak/oracle/update_submission_deadline.cdc"
 )
 
 func GenerateCreateRunScript(env Environment) []byte {
@@ -38,6 +39,12 @@ func GenerateUpdateFastBreakGameScript(env Environment) []byte {
 
 func GenerateScoreFastBreakSubmissionScript(env Environment) []byte {
 	code := assets.MustAssetString(transactionsPath + scoreFastBreakSubmissionFilename)
+
+	return []byte(replaceAddresses(code, env))
+}
+
+func GenerateUpdateSubmissionDeadlineScript(env Environment) []byte {
+	code := assets.MustAssetString(transactionsPath + updateSubmissionDeadlineFilename)
 
 	return []byte(replaceAddresses(code, env))
 }

--- a/lib/go/templates/topshot_admin_templates.go
+++ b/lib/go/templates/topshot_admin_templates.go
@@ -27,7 +27,15 @@ const (
 	createNewSubeditionAdminResourceFilename = "admin/create_new_subedition_admin_resource.cdc"
 	createSubeditionFilename                 = "admin/create_subedition.cdc"
 	setNFTsubedition                         = "admin/set_nft_subedition.cdc"
+	setIpfsCidsFilename                      = "admin/set_ipfs_cids.cdc"
 )
+
+// GenerateSetIpfsCidsScript batches IPFS CIDs for (setID, playID, subeditionID, mediaType) tuples
+func GenerateSetIpfsCidsScript(env Environment) []byte {
+	code := assets.MustAssetString(transactionsPath + setIpfsCidsFilename)
+
+	return []byte(replaceAddresses(code, env))
+}
 
 // GenerateMintPlayScript creates a new play data struct
 // and initializes it with metadata


### PR DESCRIPTION
## Summary

Three small, independent fixes surfaced by a full pass over the contracts, transactions, Go layer, and EVM bridge.

1. **Go call surface completion.** `embed.go` and `lib/go/templates` exposed 113 of 115 transaction files. The two missing transactions are added: `transactions/admin/set_ipfs_cids.cdc` (as `AdminSetIpfsCids` + `GenerateSetIpfsCidsScript`) and `transactions/fastbreak/oracle/update_submission_deadline.cdc` (as `FastbreakOracleUpdateSubmissionDeadline` + `GenerateUpdateSubmissionDeadlineScript`). The bindata assets already packed both files — only the exported vars/functions were missing.

2. **README market status drift.** The README claimed the improved market contract was "NOT DEPLOYED to mainnet" while `TopShotMarketV3` has been the operative contract (Mainnet `0xc1e4f4f4c4257510`, Testnet `0x547f177b243b4d80` — already in the address table). The address-table label, the V1-era marketplace section, and the "Different Versions of the Market Contract" section are corrected: V3 operative, V2 deployed-but-unused, `Market.cdc` legacy fallback only.

3. **Bridge hygiene.** `BridgedTopShotMoments` (and the test contract) emits ERC-4906 `MetadataUpdate` events but did not declare `IERC4906` in `supportsInterface`, so ERC-165 clients could not detect metadata refresh support. Declared in both. `InitialTestingDeploy.s.sol` hardcodes placeholder addresses (`0x12345`/`0x67890`) and a cryptokitties token URI; it is marked test-only so it cannot be mistaken for a production deployment path.

## Verification

- `make ci` green on the committed tree (generate → tidy → diff gate, plus the full emulator test suite).
- Foundry: 19/19 tests pass, including `test_SupportsInterface`.
- Branch cut from the verified master tip `9aeef65` (checked against the API).

## Out of scope

A full capability analysis of the repo (registry-style documentation of state machines, invariants, failure catalogs, and idempotency boundaries) exists alongside this change set and is being held for an internal review location; this PR carries only the code-level fixes it surfaced.